### PR TITLE
Add custom_alarms variable for user-defined CloudWatch alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,74 @@ module "alarms" {
   high_priority_alarm = []
 }
 ```
+
+## Custom Alarms
+
+In addition to the built-in alarms for common RDS metrics, you can define custom alarms for any CloudWatch metric using the `custom_alarms` variable.
+
+### Basic Usage
+
+```hcl
+module "alarms" {
+  source = "cloudomat/rds_alarms/aws"
+
+  db_instance = data.aws_db_instance.instance
+
+  low_priority_alarm  = [aws_sns_topic.alerts_low.arn]
+  high_priority_alarm = [aws_sns_topic.alerts_high.arn]
+
+  # Built-in alarms
+  cpu_utilization_high_threshold  = 80
+  cpu_utilization_vhigh_threshold = 95
+
+  # Custom alarms
+  custom_alarms = {
+    "connection_availability" = {
+      metric_name    = "DatabaseConnections"
+      low_threshold  = 20   # Warning when too few connections
+      vlow_threshold = 10   # Critical when too few connections
+      description    = "Database Connections"
+      unit           = " connections"
+    }
+  }
+}
+```
+
+### Bidirectional Alarming
+
+You can alarm on both high AND low values for the same metric, useful for detecting both overload and unavailability:
+
+```hcl
+custom_alarms = {
+  "connection_health" = {
+    metric_name     = "DatabaseConnections"
+    high_threshold  = 1000  # Warning when too many connections
+    vhigh_threshold = 1500  # Critical when too many connections
+    low_threshold   = 20    # Warning when too few connections
+    vlow_threshold  = 10    # Critical when too few connections
+    description     = "Database Connections"
+    unit            = " connections"
+  }
+}
+```
+
+This creates 4 separate alarms:
+- Warning when > 1000 connections (low priority)
+- Critical when > 1500 connections (high priority)
+- Warning when < 20 connections (low priority)
+- Critical when < 10 connections (high priority)
+
+### Available Options
+
+- `metric_name` (required): The CloudWatch metric name (e.g., "DatabaseConnections", "NetworkReceiveThroughput")
+- `high_threshold`: Low priority alarm when metric > threshold
+- `vhigh_threshold`: High priority alarm when metric > threshold
+- `low_threshold`: Low priority alarm when metric < threshold
+- `vlow_threshold`: High priority alarm when metric < threshold
+- `description`: Human-readable name for the alarm (defaults to metric name)
+- `unit`: Unit suffix for alarm descriptions (e.g., "ms", "%", " connections")
+- `statistic`: CloudWatch statistic (default: "Average")
+- `period`: Evaluation period in seconds (default: 300)
+- `evaluation_periods`: Number of periods before alarming (default: 1)
+
+All custom alarms automatically use the AWS/RDS namespace and include the DBInstanceIdentifier dimension.

--- a/tests/custom_alarms.tftest.hcl
+++ b/tests/custom_alarms.tftest.hcl
@@ -1,0 +1,481 @@
+mock_provider "aws" {}
+
+variables {
+  db_instance = {
+    identifier     = "test"
+    instance_class = "db.m6i.2xlarge"
+    storage_type   = "gp3"
+  }
+  low_priority_alarm                           = ["arn:aws:sns:us-east-1:111111111111:alerts_low"]
+  high_priority_alarm                          = ["arn:aws:sns:us-east-1:111111111111:alerts_high"]
+  cpu_utilization_high_threshold               = null
+  cpu_utilization_vhigh_threshold              = null
+  free_storage_space_percentage_low_threshold  = null
+  free_storage_space_percentage_vlow_threshold = null
+  read_latency_high_threshold                  = null
+  read_latency_vhigh_threshold                 = null
+  write_latency_high_threshold                 = null
+  write_latency_vhigh_threshold                = null
+}
+
+# Test 1: No custom alarms (baseline - verify backward compatibility)
+run "no_custom_alarms" {
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 0
+    error_message = <<-EOM
+    Expected no alarms when no thresholds set.
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+}
+
+# Test 2: Simple unidirectional custom alarm (low direction)
+run "simple_low_direction_alarm" {
+  variables {
+    custom_alarms = {
+      "connection_availability" = {
+        metric_name    = "DatabaseConnections"
+        low_threshold  = 20
+        vlow_threshold = 10
+        description    = "Database Connections"
+        unit           = " connections"
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 2
+    error_message = <<-EOM
+    Expected 2 alarms for bidirectional thresholds.
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  # Low priority alarm (low_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "low_custom_connection_availability_low")
+    error_message = "Expected alarm with key 'low_custom_connection_availability_low' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_name == "RDS ${var.db_instance.identifier} Database Connections Low"
+    error_message = <<-EOM
+    Incorrect low priority alarm name.
+    Expected: RDS ${var.db_instance.identifier} Database Connections Low
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_name, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_description == "${var.db_instance.identifier} Database Connections is below 20 connections"
+    error_message = <<-EOM
+    Incorrect low priority alarm description.
+    Expected: ${var.db_instance.identifier} Database Connections is below 20 connections
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_description, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].threshold == 20
+    error_message = "Expected threshold 20, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].threshold, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].comparison_operator == "LessThanOrEqualToThreshold"
+    error_message = "Expected LessThanOrEqualToThreshold, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].comparison_operator, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].metric_name == "DatabaseConnections"
+    error_message = "Expected metric_name DatabaseConnections, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].metric_name, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].namespace == "AWS/RDS"
+    error_message = "Expected namespace AWS/RDS, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].namespace, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].statistic == "Average"
+    error_message = "Expected default statistic Average, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].statistic, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].period == 300
+    error_message = "Expected default period 300, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].period, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].evaluation_periods == 1
+    error_message = "Expected default evaluation_periods 1, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].evaluation_periods, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_actions == toset(var.low_priority_alarm)
+    error_message = "Expected low priority SNS topic, got ${try(join(", ", aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].alarm_actions), "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].dimensions == tomap({ DBInstanceIdentifier = var.db_instance.identifier })
+    error_message = "Expected DBInstanceIdentifier dimension, got ${try(jsonencode(aws_cloudwatch_metric_alarm.alarms["low_custom_connection_availability_low"].dimensions), "ALARM NOT FOUND")}"
+  }
+
+  # High priority alarm (vlow_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_connection_availability_low")
+    error_message = "Expected alarm with key 'high_custom_connection_availability_low' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_name == "RDS ${var.db_instance.identifier} Database Connections Very Low"
+    error_message = <<-EOM
+    Incorrect high priority alarm name.
+    Expected: RDS ${var.db_instance.identifier} Database Connections Very Low
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_name, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_description == "${var.db_instance.identifier} Database Connections is below 10 connections"
+    error_message = <<-EOM
+    Incorrect high priority alarm description.
+    Expected: ${var.db_instance.identifier} Database Connections is below 10 connections
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_description, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].threshold == 10
+    error_message = "Expected threshold 10, got ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].threshold, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].comparison_operator == "LessThanOrEqualToThreshold"
+    error_message = "Expected LessThanOrEqualToThreshold, got ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].comparison_operator, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_actions == toset(var.high_priority_alarm)
+    error_message = "Expected high priority SNS topic, got ${try(join(", ", aws_cloudwatch_metric_alarm.alarms["high_custom_connection_availability_low"].alarm_actions), "ALARM NOT FOUND")}"
+  }
+}
+
+# Test 3: Simple unidirectional custom alarm (high direction)
+run "simple_high_direction_alarm" {
+  variables {
+    custom_alarms = {
+      "query_rate" = {
+        metric_name     = "Queries"
+        high_threshold  = 1000
+        vhigh_threshold = 2000
+        statistic       = "Sum"
+        period          = 60
+        unit            = " queries/min"
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 2
+    error_message = <<-EOM
+    Expected 2 alarms for high direction thresholds.
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  # Low priority alarm (high_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "low_custom_query_rate_high")
+    error_message = "Expected alarm with key 'low_custom_query_rate_high' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].alarm_name == "RDS ${var.db_instance.identifier} Queries High"
+    error_message = <<-EOM
+    Incorrect alarm name.
+    Expected: RDS ${var.db_instance.identifier} Queries High
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].alarm_name, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].alarm_description == "${var.db_instance.identifier} Queries is above 1000 queries/min"
+    error_message = <<-EOM
+    Incorrect alarm description.
+    Expected: ${var.db_instance.identifier} Queries is above 1000 queries/min
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].alarm_description, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].threshold == 1000
+    error_message = "Expected threshold 1000, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].threshold, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].comparison_operator == "GreaterThanOrEqualToThreshold"
+    error_message = "Expected GreaterThanOrEqualToThreshold, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].comparison_operator, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].statistic == "Sum"
+    error_message = "Expected statistic Sum, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].statistic, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].period == 60
+    error_message = "Expected period 60, got ${try(aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].period, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_query_rate_high"].alarm_actions == toset(var.low_priority_alarm)
+    error_message = "Expected low priority SNS topic"
+  }
+
+  # High priority alarm (vhigh_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_query_rate_high")
+    error_message = "Expected alarm with key 'high_custom_query_rate_high' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_query_rate_high"].alarm_name == "RDS ${var.db_instance.identifier} Queries Very High"
+    error_message = <<-EOM
+    Incorrect alarm name.
+    Expected: RDS ${var.db_instance.identifier} Queries Very High
+    Got: ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_query_rate_high"].alarm_name, "ALARM NOT FOUND")}
+    EOM
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_query_rate_high"].threshold == 2000
+    error_message = "Expected threshold 2000, got ${try(aws_cloudwatch_metric_alarm.alarms["high_custom_query_rate_high"].threshold, "ALARM NOT FOUND")}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_query_rate_high"].alarm_actions == toset(var.high_priority_alarm)
+    error_message = "Expected high priority SNS topic"
+  }
+}
+
+# Test 4: Bidirectional alarm (both high AND low thresholds on same metric)
+run "bidirectional_alarm" {
+  variables {
+    custom_alarms = {
+      "connection_health" = {
+        metric_name     = "DatabaseConnections"
+        high_threshold  = 1000  # Too many connections (warning)
+        vhigh_threshold = 1500  # Too many connections (critical)
+        low_threshold   = 20    # Too few connections (warning)
+        vlow_threshold  = 10    # Too few connections (critical)
+        unit            = " connections"
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 4
+    error_message = <<-EOM
+    Expected 4 alarms for bidirectional thresholds (2 high + 2 low).
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  # High direction - low priority (high_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "low_custom_connection_health_high")
+    error_message = "Expected alarm 'low_custom_connection_health_high' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_high"].alarm_name == "RDS ${var.db_instance.identifier} DatabaseConnections High"
+    error_message = "Incorrect alarm name for high direction warning"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_high"].threshold == 1000
+    error_message = "Expected threshold 1000, got ${aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_high"].threshold}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_high"].comparison_operator == "GreaterThanOrEqualToThreshold"
+    error_message = "Expected GreaterThanOrEqualToThreshold for high direction"
+  }
+
+  # High direction - high priority (vhigh_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_connection_health_high")
+    error_message = "Expected alarm 'high_custom_connection_health_high' not found"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_health_high"].alarm_name == "RDS ${var.db_instance.identifier} DatabaseConnections Very High"
+    error_message = "Incorrect alarm name for high direction critical"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_health_high"].threshold == 1500
+    error_message = "Expected threshold 1500"
+  }
+
+  # Low direction - low priority (low_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "low_custom_connection_health_low")
+    error_message = "Expected alarm 'low_custom_connection_health_low' not found"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_low"].alarm_name == "RDS ${var.db_instance.identifier} DatabaseConnections Low"
+    error_message = "Incorrect alarm name for low direction warning"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_low"].threshold == 20
+    error_message = "Expected threshold 20"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_custom_connection_health_low"].comparison_operator == "LessThanOrEqualToThreshold"
+    error_message = "Expected LessThanOrEqualToThreshold for low direction"
+  }
+
+  # Low direction - high priority (vlow_threshold)
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_connection_health_low")
+    error_message = "Expected alarm 'high_custom_connection_health_low' not found"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_health_low"].alarm_name == "RDS ${var.db_instance.identifier} DatabaseConnections Very Low"
+    error_message = "Incorrect alarm name for low direction critical"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_connection_health_low"].threshold == 10
+    error_message = "Expected threshold 10"
+  }
+}
+
+# Test 5: Single threshold only (only vlow_threshold)
+run "single_threshold_only" {
+  variables {
+    custom_alarms = {
+      "network_throughput" = {
+        metric_name    = "NetworkReceiveThroughput"
+        vlow_threshold = 300000
+        unit           = " bytes/sec"
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 1
+    error_message = <<-EOM
+    Expected 1 alarm for single threshold.
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_network_throughput_low")
+    error_message = "Expected alarm 'high_custom_network_throughput_low' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_network_throughput_low"].alarm_name == "RDS ${var.db_instance.identifier} NetworkReceiveThroughput Very Low"
+    error_message = "Incorrect alarm name"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_network_throughput_low"].threshold == 300000
+    error_message = "Expected threshold 300000"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_custom_network_throughput_low"].alarm_actions == toset(var.high_priority_alarm)
+    error_message = "Expected high priority SNS topic"
+  }
+}
+
+# Test 6: Custom alarms with built-in alarms
+run "custom_with_builtin_alarms" {
+  variables {
+    cpu_utilization_high_threshold = 80
+
+    custom_alarms = {
+      "low_connections" = {
+        metric_name    = "DatabaseConnections"
+        vlow_threshold = 10
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 2
+    error_message = <<-EOM
+    Expected 2 alarms (1 built-in + 1 custom).
+    Got ${length(keys(aws_cloudwatch_metric_alarm.alarms))} alarms: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "low_cpu_utilization")
+    error_message = "Expected built-in alarm 'low_cpu_utilization' not found"
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.alarms), "high_custom_low_connections_low")
+    error_message = "Expected custom alarm 'high_custom_low_connections_low' not found. Available: ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}"
+  }
+}
+
+# Test 7: Description handling (explicit vs metric name)
+run "description_handling" {
+  variables {
+    custom_alarms = {
+      "test1" = {
+        metric_name     = "DiskQueueDepth"
+        vhigh_threshold = 64
+        # No description provided - should use metric name as-is
+      }
+
+      "test2" = {
+        metric_name    = "CustomMetricName"
+        description    = "Custom Description"
+        vhigh_threshold = 100
+        # Explicit description provided
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 2
+    error_message = "Expected 2 alarms for description test"
+  }
+
+  # Test metric name used as-is when no description
+  assert {
+    condition     = length(regexall("DiskQueueDepth", aws_cloudwatch_metric_alarm.alarms["high_custom_test1_high"].alarm_description)) > 0
+    error_message = "Expected metric name 'DiskQueueDepth' in alarm description, got: ${aws_cloudwatch_metric_alarm.alarms["high_custom_test1_high"].alarm_description}"
+  }
+
+  # Test explicit description
+  assert {
+    condition     = length(regexall("Custom Description", aws_cloudwatch_metric_alarm.alarms["high_custom_test2_high"].alarm_description)) > 0
+    error_message = "Expected 'Custom Description' in alarm description, got: ${aws_cloudwatch_metric_alarm.alarms["high_custom_test2_high"].alarm_description}"
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for user-defined custom alarms via the `custom_alarms` variable, allowing users to quickly add alarms for metrics not covered by the built-in alarms.

## Changes

- Added `custom_alarms` variable (variables.tf) with support for bidirectional thresholds
- Updated CLAUDE.md with custom alarms design documentation
- Updated README.md with custom alarms usage examples
- Added comprehensive test coverage in tests/custom_alarms.tftest.hcl (7 test cases)
- Integrated custom alarms into the existing alarm generation pipeline (main.tf)

## Key Features

- **Bidirectional support**: Can set both high and low thresholds on the same metric
- **Threshold naming indicates direction**: high/vhigh for upper bounds, low/vlow for lower bounds
- **Flexible configuration**: Supports custom statistic, period, and evaluation_periods
- **Seamless integration**: Flows through the same dynamic alarm resource as built-in alarms

## Testing

All tests passing:
- 7 new test cases for custom alarms
- Tests cover unidirectional, bidirectional, single threshold, and integration scenarios
- Validates alarm naming, thresholds, SNS actions, and metric configuration

## Related

This is part 2 of 3 related PRs. Depends on #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)