### PR TITLE
Add three new metrics for v0.3.0: DiskQueueDepth, FreeableMemory, SwapUsage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,34 @@ locals {
       metric_name        = "WriteLatency"
       metric_postfix     = "ms"
       directionality     = "high"
+    },
+    disk_queue_depth = {
+      low_value          = var.disk_queue_depth_high_threshold
+      high_value         = var.disk_queue_depth_vhigh_threshold
+      metric_postfix     = ""
+      metric_description = "Disk Queue Depth"
+      metric_name        = "DiskQueueDepth"
+      directionality     = "high"
+    },
+    freeable_memory = {
+      low_value          = try(var.freeable_memory_low_threshold * 1024 * 1024, null)
+      high_value         = try(var.freeable_memory_vlow_threshold * 1024 * 1024, null)
+      display_low_value  = var.freeable_memory_low_threshold
+      display_high_value = var.freeable_memory_vlow_threshold
+      metric_description = "Freeable Memory"
+      metric_name        = "FreeableMemory"
+      metric_postfix     = "MB"
+      directionality     = "low"
+    },
+    swap_usage = {
+      low_value          = try(var.swap_usage_high_threshold * 1024 * 1024, null)
+      high_value         = try(var.swap_usage_vhigh_threshold * 1024 * 1024, null)
+      display_low_value  = var.swap_usage_high_threshold
+      display_high_value = var.swap_usage_vhigh_threshold
+      metric_description = "Swap Usage"
+      metric_name        = "SwapUsage"
+      metric_postfix     = "MB"
+      directionality     = "high"
     }
   }
 

--- a/tests/alarm_selection.tftest.hcl
+++ b/tests/alarm_selection.tftest.hcl
@@ -465,3 +465,117 @@ run "burstable_instance_alarms" {
     EOM
   }
 }
+
+run "new_metrics_alarms" {
+  variables {
+    disk_queue_depth_high_threshold  = 10
+    disk_queue_depth_vhigh_threshold = 20
+    freeable_memory_low_threshold    = 512
+    freeable_memory_vlow_threshold   = 256
+    swap_usage_high_threshold        = 100
+    swap_usage_vhigh_threshold       = 200
+  }
+
+  command = plan
+
+  assert {
+    condition     = length(keys(aws_cloudwatch_metric_alarm.alarms)) == 6
+    error_message = <<-EOM
+    Did not create all expected alarms.
+    Got ${join(", ", keys(aws_cloudwatch_metric_alarm.alarms))}
+    EOM
+  }
+
+  # DiskQueueDepth tests
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_disk_queue_depth"].alarm_name == "RDS ${var.db_instance.identifier} Disk Queue Depth High"
+    error_message = "Incorrect low priority alarm name for DiskQueueDepth"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_disk_queue_depth"].alarm_name == "RDS ${var.db_instance.identifier} Disk Queue Depth Very High"
+    error_message = "Incorrect high priority alarm name for DiskQueueDepth"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_disk_queue_depth"].threshold == var.disk_queue_depth_high_threshold
+    error_message = "Incorrect low priority threshold for DiskQueueDepth"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_disk_queue_depth"].threshold == var.disk_queue_depth_vhigh_threshold
+    error_message = "Incorrect high priority threshold for DiskQueueDepth"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_disk_queue_depth"].alarm_description == "${var.db_instance.identifier} Disk Queue Depth is above ${var.disk_queue_depth_high_threshold}"
+    error_message = "Incorrect alarm description for DiskQueueDepth low priority"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_disk_queue_depth"].alarm_description == "${var.db_instance.identifier} Disk Queue Depth is above ${var.disk_queue_depth_vhigh_threshold}"
+    error_message = "Incorrect alarm description for DiskQueueDepth high priority"
+  }
+
+  # FreeableMemory tests
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_freeable_memory"].alarm_name == "RDS ${var.db_instance.identifier} Freeable Memory Low"
+    error_message = "Incorrect low priority alarm name for FreeableMemory"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_freeable_memory"].alarm_name == "RDS ${var.db_instance.identifier} Freeable Memory Very Low"
+    error_message = "Incorrect high priority alarm name for FreeableMemory"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_freeable_memory"].threshold == (512 * 1024 * 1024)
+    error_message = "Incorrect low priority threshold for FreeableMemory (should be in bytes)"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_freeable_memory"].threshold == (256 * 1024 * 1024)
+    error_message = "Incorrect high priority threshold for FreeableMemory (should be in bytes)"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_freeable_memory"].alarm_description == "${var.db_instance.identifier} Freeable Memory is below ${var.freeable_memory_low_threshold}MB"
+    error_message = "Incorrect alarm description for FreeableMemory low priority"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_freeable_memory"].alarm_description == "${var.db_instance.identifier} Freeable Memory is below ${var.freeable_memory_vlow_threshold}MB"
+    error_message = "Incorrect alarm description for FreeableMemory high priority"
+  }
+
+  # SwapUsage tests
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_swap_usage"].alarm_name == "RDS ${var.db_instance.identifier} Swap Usage High"
+    error_message = "Incorrect low priority alarm name for SwapUsage"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_swap_usage"].alarm_name == "RDS ${var.db_instance.identifier} Swap Usage Very High"
+    error_message = "Incorrect high priority alarm name for SwapUsage"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_swap_usage"].threshold == (100 * 1024 * 1024)
+    error_message = "Incorrect low priority threshold for SwapUsage (should be in bytes)"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_swap_usage"].threshold == (200 * 1024 * 1024)
+    error_message = "Incorrect high priority threshold for SwapUsage (should be in bytes)"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["low_swap_usage"].alarm_description == "${var.db_instance.identifier} Swap Usage is above ${var.swap_usage_high_threshold}MB"
+    error_message = "Incorrect alarm description for SwapUsage low priority"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.alarms["high_swap_usage"].alarm_description == "${var.db_instance.identifier} Swap Usage is above ${var.swap_usage_vhigh_threshold}MB"
+    error_message = "Incorrect alarm description for SwapUsage high priority"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,54 @@ variable "cpu_credit_balance_vlow_threshold" {
   EOM
 }
 
+variable "disk_queue_depth_high_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How high can the average disk queue depth be before a low priority alert is triggered? Set to null to disable.
+  EOM
+}
+
+variable "disk_queue_depth_vhigh_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How high can the average disk queue depth be before a high priority alert is triggered? Set to null to disable.
+  EOM
+}
+
+variable "freeable_memory_low_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How low can freeable memory (in MB) be before a low priority alert is triggered? Set to null to disable.
+  EOM
+}
+
+variable "freeable_memory_vlow_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How low can freeable memory (in MB) be before a high priority alert is triggered? Set to null to disable.
+  EOM
+}
+
+variable "swap_usage_high_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How high can swap usage (in MB) be before a low priority alert is triggered? Set to null to disable.
+  EOM
+}
+
+variable "swap_usage_vhigh_threshold" {
+  type        = number
+  default     = null
+  description = <<-EOM
+  How high can swap usage (in MB) be before a high priority alert is triggered? Set to null to disable.
+  EOM
+}
+
 variable "custom_alarms" {
   description = <<-EOT
     Custom CloudWatch alarms for additional RDS metrics.


### PR DESCRIPTION
## Summary

Implements the first milestone toward v1.0 by adding support for three new always-on RDS CloudWatch metrics:

1. **DiskQueueDepth** - Detects I/O bottlenecks
2. **FreeableMemory** - Detects memory pressure
3. **SwapUsage** - Detects memory swapping issues

## Changes

### Variables (`variables.tf`)
Added 6 new threshold variables:
- `disk_queue_depth_high_threshold` / `disk_queue_depth_vhigh_threshold`
- `freeable_memory_low_threshold` / `freeable_memory_vlow_threshold`
- `swap_usage_high_threshold` / `swap_usage_vhigh_threshold`

All default to `null` for backward compatibility.

### Metrics (`main.tf`)
Added 3 new metric configurations to the `always_on` local:

- **DiskQueueDepth**: High directionality, no unit conversion
- **FreeableMemory**: Low directionality, MB → bytes conversion (CloudWatch uses bytes)
- **SwapUsage**: High directionality, MB → bytes conversion (CloudWatch uses bytes)

### Tests (`tests/alarm_selection.tftest.hcl`)
Added comprehensive test run `new_metrics_alarms` with 18 assertions covering:
- Alarm creation (6 alarms expected)
- Alarm naming (both low and high priority)
- Threshold values and unit conversions
- Alarm descriptions

## Testing

All tests pass:
```
Success! 12 passed, 0 failed.
```

Specific tests for the new metrics verify:
- ✅ Correct alarm names generated
- ✅ Proper directionality (high vs low)
- ✅ Accurate unit conversions (MB to bytes)
- ✅ Threshold values correctly applied

## Backward Compatibility

✅ **Zero breaking changes** - All new thresholds default to `null`, so existing configurations remain unchanged.

## Related

Part of v0.3.0 release path toward v1.0 (see VISION_1.0.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)